### PR TITLE
Add hover functionality to neurons with progress indicator

### DIFF
--- a/src/components/NeuralNetworkPortfolio.tsx
+++ b/src/components/NeuralNetworkPortfolio.tsx
@@ -150,6 +150,11 @@ const NeuralNetworkPortfolio: React.FC<NeuralNetworkPortfolioProps> = ({
     }
   };
 
+  const handleNeuronHover = (project: Project) => {
+    setSelectedProject(project);
+    setIsModalOpen(true);
+  };
+
   const handleOutputClick = () => {
     setIsPersonalModalOpen(true);
   };
@@ -288,6 +293,7 @@ const NeuralNetworkPortfolio: React.FC<NeuralNetworkPortfolioProps> = ({
               project={project}
               position={currentPositions[project.id] || positions[project.id]}
               onClick={() => handleNeuronClick(project)}
+              onHover={() => handleNeuronHover(project)}
               onDrag={(newPosition) =>
                 handleNeuronDrag(project.id, newPosition)
               }

--- a/src/components/NeuralNetworkPortfolio.tsx
+++ b/src/components/NeuralNetworkPortfolio.tsx
@@ -357,7 +357,7 @@ const NeuralNetworkPortfolio: React.FC<NeuralNetworkPortfolioProps> = ({
             </div>
           </div>
           <p className="mt-2 opacity-75 text-xs">
-            Click neurons for details • Drag neurons to move them
+            Hover 2s for details • Click for instant view ��� Drag to move
           </p>
         </div>
       )}
@@ -378,7 +378,9 @@ const NeuralNetworkPortfolio: React.FC<NeuralNetworkPortfolioProps> = ({
       {isMobile && (
         <div className="absolute top-32 left-1/2 transform -translate-x-1/2 text-white text-center px-4 z-10">
           <div className="bg-black bg-opacity-50 rounded-lg px-3 py-2 backdrop-blur-sm">
-            <p className="text-xs opacity-90">🧠 Drag neurons to explore</p>
+            <p className="text-xs opacity-90">
+              🧠 Tap or drag neurons to explore
+            </p>
           </div>
         </div>
       )}

--- a/src/components/Neuron.tsx
+++ b/src/components/Neuron.tsx
@@ -1,8 +1,7 @@
-
-import React from 'react';
-import { useDrag } from '@use-gesture/react';
-import { useSpring, animated } from '@react-spring/web';
-import { NeuronProps, Position } from '@/types/project';
+import React, { useRef, useEffect } from "react";
+import { useDrag } from "@use-gesture/react";
+import { useSpring, animated } from "@react-spring/web";
+import { NeuronProps, Position } from "@/types/project";
 
 interface ExtendedNeuronProps extends NeuronProps {
   isMobile?: boolean;
@@ -10,66 +9,81 @@ interface ExtendedNeuronProps extends NeuronProps {
   isDraggable?: boolean;
 }
 
-const Neuron: React.FC<ExtendedNeuronProps> = ({ 
-  project, 
-  position, 
-  isOutput = false, 
+const Neuron: React.FC<ExtendedNeuronProps> = ({
+  project,
+  position,
+  isOutput = false,
   onClick,
+  onHover,
   onDrag,
   isDraggable = false,
-  isMobile = false
+  isMobile = false,
 }) => {
   // Individual neuron spring animation
   const [{ x, y }, api] = useSpring(() => ({ x: 0, y: 0 }));
+
+  // Hover timer ref
+  const hoverTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const isDraggingRef = useRef(false);
 
   // Individual neuron drag handler
   const bind = useDrag(
     ({ down, movement: [mx, my], event }) => {
       if (!isDraggable) return;
-      
+
       event?.stopPropagation(); // Prevent global drag
-      
+
       if (down) {
+        isDraggingRef.current = true;
+        // Clear hover timer when dragging starts
+        if (hoverTimerRef.current) {
+          clearTimeout(hoverTimerRef.current);
+          hoverTimerRef.current = null;
+        }
         api.start({ x: mx, y: my, immediate: true });
       } else {
         // When drag ends, update the position and reset spring
         if (onDrag) {
           onDrag({
             x: position.x + mx,
-            y: position.y + my
+            y: position.y + my,
           });
         }
         api.start({ x: 0, y: 0 });
+        // Reset dragging state after a short delay
+        setTimeout(() => {
+          isDraggingRef.current = false;
+        }, 100);
       }
     },
     {
-      enabled: isDraggable
-    }
+      enabled: isDraggable,
+    },
   );
 
   const getCategoryColor = (categoryId?: number) => {
     const colors = {
-      1: 'bg-blue-500',      // AI/ML
-      2: 'bg-green-500',     // Backend
-      3: 'bg-purple-500',    // Frontend
-      4: 'bg-orange-500',    // Mobile
-      5: 'bg-red-500',       // HubSpot
+      1: "bg-blue-500", // AI/ML
+      2: "bg-green-500", // Backend
+      3: "bg-purple-500", // Frontend
+      4: "bg-orange-500", // Mobile
+      5: "bg-red-500", // HubSpot
     };
-    return colors[categoryId as keyof typeof colors] || 'bg-gray-500';
+    return colors[categoryId as keyof typeof colors] || "bg-gray-500";
   };
 
   const getNeuronSize = () => {
     if (isMobile) {
-      return isOutput ? 'w-12 h-12' : 'w-8 h-8';
+      return isOutput ? "w-12 h-12" : "w-8 h-8";
     }
-    return isOutput ? 'w-16 h-16' : 'w-12 h-12';
+    return isOutput ? "w-16 h-16" : "w-12 h-12";
   };
 
   const getInnerSize = () => {
     if (isMobile) {
-      return isOutput ? 'w-8 h-8' : 'w-6 h-6';
+      return isOutput ? "w-8 h-8" : "w-6 h-6";
     }
-    return isOutput ? 'w-12 h-12' : 'w-8 h-8';
+    return isOutput ? "w-12 h-12" : "w-8 h-8";
   };
 
   const getOffset = () => {
@@ -82,41 +96,85 @@ const Neuron: React.FC<ExtendedNeuronProps> = ({
   const categoryId = project ? Math.floor(project.id / 10000) : undefined;
   const offset = getOffset();
 
+  // Hover handlers
+  const handleMouseEnter = () => {
+    if (!project || !onHover || isDraggingRef.current) return;
+
+    // Clear any existing timer
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+    }
+
+    // Set a new 2-second timer
+    hoverTimerRef.current = setTimeout(() => {
+      if (!isDraggingRef.current) {
+        onHover();
+      }
+    }, 2000);
+  };
+
+  const handleMouseLeave = () => {
+    // Clear the timer when mouse leaves
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  };
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) {
+        clearTimeout(hoverTimerRef.current);
+      }
+    };
+  }, []);
+
   const getCursorStyle = () => {
-    if (isDraggable) return 'cursor-move';
-    return 'cursor-pointer';
+    if (isDraggable) return "cursor-move";
+    return "cursor-pointer";
   };
 
   return (
     <animated.div
       {...(isDraggable ? bind() : {})}
       className={`absolute ${getNeuronSize()} rounded-full border-2 border-white shadow-lg transform transition-all duration-300 ${
-        isOutput ? 'bg-gradient-to-r from-purple-600 to-pink-600' : getCategoryColor(categoryId)
+        isOutput
+          ? "bg-gradient-to-r from-purple-600 to-pink-600"
+          : getCategoryColor(categoryId)
       } pointer-events-auto ${getCursorStyle()}`}
       style={{
         left: position.x - offset,
         top: position.y - offset,
         x: isDraggable ? x : 0,
         y: isDraggable ? y : 0,
-        touchAction: isDraggable ? 'none' : 'auto',
+        touchAction: isDraggable ? "none" : "auto",
       }}
       onClick={onClick}
-      title={project?.title || 'Mark Fahim - AI Software Engineer'}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      title={project?.title || "Mark Fahim - AI Software Engineer"}
     >
       <div className="w-full h-full rounded-full flex items-center justify-center relative">
         {isOutput ? (
-          <div className={`${getInnerSize()} rounded-full bg-white flex items-center justify-center ${
-            isMobile ? 'text-xs' : 'text-xs'
-          } font-bold text-purple-600`}>
+          <div
+            className={`${getInnerSize()} rounded-full bg-white flex items-center justify-center ${
+              isMobile ? "text-xs" : "text-xs"
+            } font-bold text-purple-600`}
+          >
             MF
           </div>
         ) : (
-          <div className={`${isMobile ? 'w-6 h-6' : 'w-8 h-8'} rounded-full bg-white bg-opacity-30 flex items-center justify-center`}>
-            <div className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'} rounded-full bg-white`}></div>
+          <div
+            className={`${isMobile ? "w-6 h-6" : "w-8 h-8"} rounded-full bg-white bg-opacity-30 flex items-center justify-center`}
+          >
+            <div
+              className={`${isMobile ? "w-3 h-3" : "w-4 h-4"} rounded-full bg-white`}
+            ></div>
           </div>
         )}
       </div>
-      
+
       {/* Pulse animation for output neuron only */}
       {isOutput && (
         <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 animate-ping opacity-30"></div>

--- a/src/components/Neuron.tsx
+++ b/src/components/Neuron.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { useDrag } from "@use-gesture/react";
 import { useSpring, animated } from "@react-spring/web";
 import { NeuronProps, Position } from "@/types/project";
@@ -22,9 +22,12 @@ const Neuron: React.FC<ExtendedNeuronProps> = ({
   // Individual neuron spring animation
   const [{ x, y }, api] = useSpring(() => ({ x: 0, y: 0 }));
 
-  // Hover timer ref
+  // Hover timer ref and progress state
   const hoverTimerRef = useRef<NodeJS.Timeout | null>(null);
   const isDraggingRef = useRef(false);
+  const [hoverProgress, setHoverProgress] = useState(0);
+  const [isHovering, setIsHovering] = useState(false);
+  const progressIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Individual neuron drag handler
   const bind = useDrag(
@@ -35,10 +38,17 @@ const Neuron: React.FC<ExtendedNeuronProps> = ({
 
       if (down) {
         isDraggingRef.current = true;
-        // Clear hover timer when dragging starts
+        setIsHovering(false);
+        setHoverProgress(0);
+
+        // Clear hover timers when dragging starts
         if (hoverTimerRef.current) {
           clearTimeout(hoverTimerRef.current);
           hoverTimerRef.current = null;
+        }
+        if (progressIntervalRef.current) {
+          clearInterval(progressIntervalRef.current);
+          progressIntervalRef.current = null;
         }
         api.start({ x: mx, y: my, immediate: true });
       } else {
@@ -96,36 +106,67 @@ const Neuron: React.FC<ExtendedNeuronProps> = ({
   const categoryId = project ? Math.floor(project.id / 10000) : undefined;
   const offset = getOffset();
 
-  // Hover handlers
+  // Hover handlers with progress animation
   const handleMouseEnter = () => {
     if (!project || !onHover || isDraggingRef.current) return;
 
-    // Clear any existing timer
+    setIsHovering(true);
+    setHoverProgress(0);
+
+    // Clear any existing timers
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
     }
+    if (progressIntervalRef.current) {
+      clearInterval(progressIntervalRef.current);
+    }
 
-    // Set a new 2-second timer
+    // Start progress animation
+    const startTime = Date.now();
+    progressIntervalRef.current = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min(elapsed / 2000, 1) * 100;
+      setHoverProgress(progress);
+
+      if (progress >= 100) {
+        clearInterval(progressIntervalRef.current!);
+        progressIntervalRef.current = null;
+      }
+    }, 16); // ~60fps
+
+    // Set the 2-second timer for modal opening
     hoverTimerRef.current = setTimeout(() => {
       if (!isDraggingRef.current) {
         onHover();
+        setIsHovering(false);
+        setHoverProgress(0);
       }
     }, 2000);
   };
 
   const handleMouseLeave = () => {
-    // Clear the timer when mouse leaves
+    setIsHovering(false);
+    setHoverProgress(0);
+
+    // Clear all timers when mouse leaves
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;
     }
+    if (progressIntervalRef.current) {
+      clearInterval(progressIntervalRef.current);
+      progressIntervalRef.current = null;
+    }
   };
 
-  // Cleanup timer on unmount
+  // Cleanup timers on unmount
   useEffect(() => {
     return () => {
       if (hoverTimerRef.current) {
         clearTimeout(hoverTimerRef.current);
+      }
+      if (progressIntervalRef.current) {
+        clearInterval(progressIntervalRef.current);
       }
     };
   }, []);
@@ -138,7 +179,11 @@ const Neuron: React.FC<ExtendedNeuronProps> = ({
   return (
     <animated.div
       {...(isDraggable ? bind() : {})}
-      className={`absolute ${getNeuronSize()} rounded-full border-2 border-white shadow-lg transform transition-all duration-300 ${
+      className={`absolute ${getNeuronSize()} rounded-full border-2 transition-all duration-300 ${
+        isHovering
+          ? "border-yellow-400 shadow-xl scale-110"
+          : "border-white shadow-lg"
+      } ${
         isOutput
           ? "bg-gradient-to-r from-purple-600 to-pink-600"
           : getCategoryColor(categoryId)
@@ -180,9 +225,43 @@ const Neuron: React.FC<ExtendedNeuronProps> = ({
         <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 animate-ping opacity-30"></div>
       )}
 
+      {/* Hover progress ring */}
+      {isHovering && project && (
+        <div className="absolute inset-0 rounded-full">
+          <svg className="w-full h-full -rotate-90" viewBox="0 0 24 24">
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              fill="none"
+              stroke="rgba(250, 204, 21, 0.3)"
+              strokeWidth="2"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              fill="none"
+              stroke="rgb(250, 204, 21)"
+              strokeWidth="2"
+              strokeDasharray="62.83"
+              strokeDashoffset={62.83 - (62.83 * hoverProgress) / 100}
+              className="transition-all duration-75 ease-linear"
+            />
+          </svg>
+        </div>
+      )}
+
       {/* Drag indicator for draggable neurons */}
-      {isDraggable && (
+      {isDraggable && !isHovering && (
         <div className="absolute -top-1 -right-1 w-3 h-3 bg-yellow-400 rounded-full opacity-60 animate-pulse"></div>
+      )}
+
+      {/* Hover instruction tooltip */}
+      {isHovering && project && (
+        <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-75 text-white text-xs px-2 py-1 rounded whitespace-nowrap z-20">
+          Hold to view details...
+        </div>
       )}
     </animated.div>
   );

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,19 +1,17 @@
 export interface Project {
-    id: number;
+  id: number;
   title: string;
   description: string;
   image: string[];
   video: string;
   linksmodel: LinkModel[];
   headerIcon: string;
+}
 
-  }
-
-  export interface LinkModel {
+export interface LinkModel {
   icons: string;
   links: string;
 }
-
 
 export interface Category {
   id: number;
@@ -32,4 +30,5 @@ export interface NeuronProps {
   position: Position;
   isOutput?: boolean;
   onClick?: () => void;
+  onHover?: () => void;
 }


### PR DESCRIPTION
Add hover functionality to neurons that opens project details after 2 seconds.

Changes made:
- Add handleNeuronHover function to NeuralNetworkPortfolio component
- Pass onHover prop to Neuron components
- Implement hover timer with 2-second delay in Neuron component
- Add visual progress ring animation during hover
- Add hover tooltip showing "Hold to view details..."
- Prevent hover action when dragging neurons
- Update instruction text to reflect new hover behavior
- Add onHover prop to NeuronProps interface

The hover functionality includes a visual progress indicator and prevents conflicts with drag operations.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/42353e9d97cf41a686d8e0121510d883/glow-studio)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>42353e9d97cf41a686d8e0121510d883</projectId>-->
<!--<branchName>glow-studio</branchName>-->